### PR TITLE
feat: use ya.clipboard() for copying file contents

### DIFF
--- a/copy-file-contents.yazi/README.md
+++ b/copy-file-contents.yazi/README.md
@@ -6,7 +6,7 @@ A simple plugin to copy file contents just from Yazi without going into editor.
 
 - Copy one or more file contents to clipboard.
 - Set custom separator for copied contents.
-- Set custom clipboard command.
+- It utilises yazi's `ya.clipboard()` to copy contents to clipboard, taking care of binary files too.
 
 ## Preview
 
@@ -37,7 +37,6 @@ Add the below to your `~/.config/yazi/init.lua` file to set custom options for t
 
 ```lua
 require("copy-file-contents"):setup({
-	clipboard_cmd = "default",
 	append_char = "\n",
 	notification = true,
 })
@@ -45,28 +44,5 @@ require("copy-file-contents"):setup({
 
 ## Options
 
-1. `clipboard_cmd`: Set the clipboard command to use. Use `"default"` to use the default command based on the OS.
-
-```lua
-OS_clipboard_mapping = {
-	["linux"] = "xclip -selection clipboard",
-	["macos"] = "pbcopy",
-	["windows"] = "clip",
-	["ios"] = "pbcopy",
-	["freebsd"] = "xclip -selection clipboard",
-	["dragonfly"] = "xclip -selection clipboard",
-	["netbsd"] = "xclip -selection clipboard",
-	["openbsd"] = "xclip -selection clipboard",
-	["solaris"] = "xclip -selection clipboard",
-	["android"] = "termux-clipboard-set",
-}
-```
-
-You can set the `clipboard_cmd` to any of the above commands. The command run to copy the contents will be run as -
-
-```bash
-echo file_name | clipboard_cmd
-```
-
-2. `append_char`: Set the character to append at the end of each copied file content. Default is `"\n"`.
-3. `notification`: Set to `true/false` to enable/disable notification after copying the contents. Default is `true`.
+1. `append_char`: Set the character to append at the end of each copied file content. Default is `"\n"`.
+2. `notification`: Set to `true/false` to enable/disable notification after copying the contents. Default is `true`.

--- a/copy-file-contents.yazi/init.lua
+++ b/copy-file-contents.yazi/init.lua
@@ -17,20 +17,6 @@ local function notify(str)
 	})
 end
 
--- Mapping for OS and its corresponding content copy command
-local OS_clipboard_mapping = {
-	["linux"] = "xclip -selection clipboard",
-	["macos"] = "pbcopy",
-	["windows"] = "clip",
-	["ios"] = "pbcopy",
-	["freebsd"] = "xclip -selection clipboard",
-	["dragonfly"] = "xclip -selection clipboard",
-	["netbsd"] = "xclip -selection clipboard",
-	["openbsd"] = "xclip -selection clipboard",
-	["solaris"] = "xclip -selection clipboard",
-	["android"] = "termux-clipboard-set",
-}
-
 local state_option = ya.sync(function(state, attr)
 	return state[attr]
 end)
@@ -42,8 +28,7 @@ local function entry()
 		return
 	end
 	-- call the attributes from setup
-	local append_char, notification, clipboard_cmd =
-		state_option("append_char"), state_option("notification"), state_option("clipboard_cmd")
+	local append_char, notification = state_option("append_char"), state_option("notification")
 
 	local text = ""
 	for i, file in ipairs(files) do
@@ -60,16 +45,8 @@ local function entry()
 		end
 	end
 
-	local cmd_args = "echo " .. ya.quote(text) .. " | " .. clipboard_cmd
-	local shell_value = os.getenv("SHELL"):match(".*/(.*)")
-
-	-- Spawn the command to copy the file contents to clipboard
-	local output, err = Command(shell_value):args({ "-c", cmd_args }):spawn():wait()
-
-	if not output then
-		return ya.err("Cannot spawn clipboard command, error code " .. tostring(err))
-	end
-
+	-- Copy the file contents to clipboard
+	ya.clipboard(text)
 	-- Notify the user that the file contents have been copied to clipboard
 	if notification then
 		notify("Copied file contents to clipboard")
@@ -82,11 +59,6 @@ return {
 		state.append_char = options.append_char or "\n"
 		-- Enable notification
 		state.notification = options.notification and true
-		-- Set the clipboard command based on the OS
-		state.clipboard_cmd = options.clipboard_cmd or OS_clipboard_mapping[ya.target_os()]
-		if state.clipboard_cmd:lower() == "default" or state.clipboard_cmd == nil or state.clipboard_cmd == "" then
-			state.clipboard_cmd = OS_clipboard_mapping[ya.target_os()]
-		end
 	end,
 	entry = entry,
 }

--- a/copy-file-contents.yazi/init.lua
+++ b/copy-file-contents.yazi/init.lua
@@ -49,7 +49,7 @@ local function entry()
 	ya.clipboard(text)
 	-- Notify the user that the file contents have been copied to clipboard
 	if notification then
-		notify("Copied file contents to clipboard")
+		notify("Copied " .. #files .. " file(s) contents to clipboard")
 	end
 end
 


### PR DESCRIPTION
As suggested in #1, use `ya.clipboard()` to copy file contents. ~This will ensure that files are copied even from binary files~ Edit: Previously and currently binary files are not getting copied. This way we dont have to worry copy which command is being used to command, its prebuilt.

Thanks to @sxyazi!!!